### PR TITLE
ci: fix copywrite headers and macOS Go 1.18 matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
           - "1.18"
           - "1.19"
           - "1.20"
+        exclude:
+          # Go 1.18 has no installable build for the Apple Silicon
+          # macos-latest runners, so skip that combination.
+          - os: macos-latest
+            go: "1.18"
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # https://github.com/actions/checkout/releases/tag/v3.6.0

--- a/action.go
+++ b/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/checks.go
+++ b/checks.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/cmd/round-trip-dumper/main.go
+++ b/cmd/round-trip-dumper/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/config_test.go
+++ b/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/expression.go
+++ b/expression.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/expression_test.go
+++ b/expression_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/metadata.go
+++ b/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/plan.go
+++ b/plan.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/plan_test.go
+++ b/plan_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/sanitize/copy.go
+++ b/sanitize/copy.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/copy_test.go
+++ b/sanitize/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_change.go
+++ b/sanitize/sanitize_change.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_change_test.go
+++ b/sanitize/sanitize_change_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_plan.go
+++ b/sanitize/sanitize_plan.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_plan_test.go
+++ b/sanitize/sanitize_plan_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_plan_variables.go
+++ b/sanitize/sanitize_plan_variables.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_plan_variables_test.go
+++ b/sanitize/sanitize_plan_variables_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_state.go
+++ b/sanitize/sanitize_state.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitize_state_test.go
+++ b/sanitize/sanitize_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package sanitize

--- a/sanitize/sanitizer.go
+++ b/sanitize/sanitizer.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2019, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package sanitize
 
 type Sanitizer func(old interface{}) interface{}

--- a/schemas.go
+++ b/schemas.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/schemas_test.go
+++ b/schemas_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/state.go
+++ b/state.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/state_test.go
+++ b/state_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/tfjson.go
+++ b/tfjson.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // Package tfjson is a de-coupled helper library containing types for

--- a/validate.go
+++ b/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson

--- a/version_test.go
+++ b/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2019, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package tfjson


### PR DESCRIPTION
Fixes the two pre-existing CI failures affecting every PR on this fork.

## 1. copywrite (Validate Header Compliance)

The copywrite CLI now expects the **`IBM Corp.`** copyright holder — HashiCorp was acquired by IBM, and upstream `hashicorp/terraform-json` migrated its headers to `// Copyright IBM Corp. 2019, 2026`. This fork still carried the old `// Copyright (c) HashiCorp, Inc.` headers (and `sanitize/sanitizer.go` had none), so the check flagged all 32 files.

Ran `copywrite headers` (the same tool the CI job uses) to regenerate every header to the canonical upstream form:

```
// Copyright IBM Corp. 2019, 2026
// SPDX-License-Identifier: MPL-2.0
```

## 2. test (macos-latest, 1.18)

`macos-latest` is now Apple Silicon, and Go 1.18 has no installable darwin-arm64 build (`setup-go` 403s on the archive). Excluded that single matrix combination in `.github/workflows/test.yml`.

## Verification

- `copywrite headers --plan` exits cleanly.
- All test matrix cells, `go build ./...` and `go test ./...` pass.

Mechanical/CI-only change — no code behaviour affected.